### PR TITLE
fix: restore smart-vercel yaml comment output

### DIFF
--- a/actions/smart-vercel/action.yml
+++ b/actions/smart-vercel/action.yml
@@ -178,6 +178,7 @@ runs:
         cd ${{ inputs.workdir }}
         DIR_NAME=${{ steps.dir-name.outputs.DIR_NAME }}
         REPO_NAME=${{ steps.repo-name.outputs.REPO_NAME }}
+        FORMAT_PREVIEW_OUTPUT=${{ github.action_path }}/bin/render-preview-output.sh
         VERCEL_TOKEN=${{ inputs.vercel_token }}
         VERCEL_GROUP=${{ inputs.vercel_group }}
         PREVIEW_OUTPUT=${{ inputs.preview_output }}
@@ -239,10 +240,7 @@ runs:
           fi
         done
 
-        content="${DEPLOYMENT_URL//'%'/'%25'}"
-        content="${content//$'\n'/'%0A'}"
-        content="${content//$'\r'/'%0D'}"
-        PREVIEW_LINK="${content}"
+        PREVIEW_LINK=$("${FORMAT_PREVIEW_OUTPUT}" normalize-link "${DEPLOYMENT_URL}")
 
         for DOMAIN in ${ALL_ALIAS_DOMAIN}
         do
@@ -268,25 +266,7 @@ runs:
             SHA=${{ github.event.pull_request.head.sha }}
             SHA=${SHA::7}
           fi
-          COMMIT="Commit: [${SHA}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${SHA})"
-          PREVIEW="Preview: ${PREVIEW_LINK}"
-
-          if [ -n "${PREVIEW_SECTION}" ]; then
-            echo "\---${PREVIEW_SECTION}---" >> comment.md
-          else
-            echo '\---' >> comment.md
-          fi
-          echo $COMMIT >> comment.md
-          echo $PREVIEW >> comment.md
-          echo '' >> comment.md
-
-          content=$(cat comment.md)
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
-          PREVIEW_OUTPUT=${content}
-
-          rm -rf comment.md
+          PREVIEW_OUTPUT=$("${FORMAT_PREVIEW_OUTPUT}" render-entry "${SHA}" "${PREVIEW_LINK}" "${PREVIEW_SECTION}")
 
           {
             echo 'PREVIEW_OUTPUT<<EOF'

--- a/actions/smart-vercel/bin/render-preview-output.sh
+++ b/actions/smart-vercel/bin/render-preview-output.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+normalize_link() {
+  printf '%s' "${1}" | tr '\r\n' ' ' | sed 's/[[:space:]]\+/ /g; s/^ //; s/ $//'
+}
+
+render_entry() {
+  local sha="$1"
+  local preview_link
+  local preview_section="${3:-}"
+
+  preview_link="$(normalize_link "$2")"
+
+  if [ -n "${preview_section}" ]; then
+    printf -- "- section: %s\n  comment: %s\n  preview: %s\n" "${preview_section}" "${sha}" "${preview_link}"
+    return
+  fi
+
+  printf -- "- comment: %s\n  preview: %s\n" "${sha}" "${preview_link}"
+}
+
+usage() {
+  echo "usage: $0 <normalize-link|render-entry> ..." >&2
+  exit 1
+}
+
+main() {
+  local command="${1:-}"
+
+  case "${command}" in
+    normalize-link)
+      [ $# -eq 2 ] || usage
+      normalize_link "$2"
+      ;;
+    render-entry)
+      [ $# -ge 3 ] && [ $# -le 4 ] || usage
+      render_entry "$2" "$3" "${4:-}"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/test-smart-vercel-comment-format.sh
+++ b/scripts/test-smart-vercel-comment-format.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORMATTER="${ROOT_DIR}/actions/smart-vercel/bin/render-preview-output.sh"
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local name="$3"
+
+  if [ "${expected}" != "${actual}" ]; then
+    echo "assertion failed: ${name}" >&2
+    echo "expected:" >&2
+    printf '%s\n' "${expected}" >&2
+    echo "actual:" >&2
+    printf '%s\n' "${actual}" >&2
+    exit 1
+  fi
+}
+
+main() {
+  local actual expected
+
+  actual="$("${FORMATTER}" render-entry "f56896b" "https://degov-home-a19ab32qi-itering.vercel.app")"
+  expected=$'- comment: f56896b\n  preview: https://degov-home-a19ab32qi-itering.vercel.app'
+  assert_eq "${expected}" "${actual}" "renders yaml-style preview entry"
+
+  actual="$("${FORMATTER}" render-entry "113a1fd" $'https://degov-home-mbjpfedv3-itering.vercel.app\nhttps://alias.vercel.app' "staging")"
+  expected=$'- section: staging\n  comment: 113a1fd\n  preview: https://degov-home-mbjpfedv3-itering.vercel.app https://alias.vercel.app'
+  assert_eq "${expected}" "${actual}" "normalizes multiline preview links and preserves section metadata"
+
+  actual="$("${FORMATTER}" normalize-link $'https://preview.vercel.app\r\nhttps://alias.vercel.app')"
+  expected='https://preview.vercel.app https://alias.vercel.app'
+  assert_eq "${expected}" "${actual}" "normalizes raw preview link output"
+
+  echo "smart-vercel comment formatter tests passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- restore `smart-vercel` preview comments to readable YAML-style list entries
- stop percent-encoding multiline preview outputs before passing them to the sticky PR comment action
- add a shell regression script for preview-entry formatting and link normalization

## Testing
- bash scripts/test-smart-vercel-comment-format.sh
- git diff --check

## Linear
- OHH-26
